### PR TITLE
feature(Node): use `uws`, if available

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,3 +1,10 @@
 "use strict";
 
-module.exports = require('ws');
+var ws;
+try {
+  ws = require('uws');
+} catch (e) {
+  ws = require('ws');
+}
+
+module.exports = ws;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "isomorphic-ws",
-  "version": "3.2.0",
+  "version": "4.0.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/heineiuo/isomorphic-ws#readme",
   "peerDependencies": {
+    "uws": "*",
     "ws": "*"
   },
   "files": [


### PR DESCRIPTION
> [`uws`](https://www.npmjs.com/package/uws) is a replacement module for `ws` which allows, but doesn't guarantee, significant performance and memory-usage improvements. 

This PR add the ability for `isomorphic-ws` to use `uws` if it is available; otherwise fallback to `ws`.