### PR TITLE
Access data field in the object that comes back to make example work

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ ws.onclose = function close() {
 };
 
 ws.onmessage = function incoming(data) {
-  console.log(`Roundtrip time: ${Date.now() - data} ms`);
+  console.log(`Roundtrip time: ${Date.now() - data.data} ms`);
 
   setTimeout(function timeout() {
     ws.send(Date.now());


### PR DESCRIPTION
Noticed this:
```
connected
Roundtrip time: NaN ms
Roundtrip time: NaN ms
Roundtrip time: NaN ms
```
and found the object coming back has a field called `data` which has the info necessary to do the calculation. This fix makes the example work:
```
connected
Roundtrip time: 94 ms
Roundtrip time: 80 ms
Roundtrip time: 27 ms
```