### PR TITLE
Update server url in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then just require this package:
 ```js
 const WebSocket = require('isomorphic-ws');
 
-const ws = new WebSocket('wss://echo.websocket.org/');
+const ws = new WebSocket('wss://websocket-echo.com/');
 
 ws.onopen = function open() {
   console.log('connected');


### PR DESCRIPTION
Hi. The `echo.websocket.org` service is no longer available, so the example in the readme doesn't work.

I updated it to `websocket-echo.com`, which is also what `ws` [uses in its readme](https://github.com/websockets/ws#round-trip-time). 

